### PR TITLE
Use one global HTTP Client and Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Go library for current & historical exchange rates, forex & crypto currency conv
 
 ## Features:
 - Currency conversion, historical & current exchange rates, timeseries and fluctuations
-- No authentication/token needed!
 - Select any base currency
 - 171 forex currency and 6000+ cryptocurrency!
 - Caching (optional, default) using [go-cache](https://github.com/patrickmn/go-cache)
@@ -25,6 +24,9 @@ import (
 )
 
 func main() {
+  // Set exchangerate.host ACCESS_KEY - either this way or via the EXCHANGERATE_ACCESS_KEY environment variable
+  exchange.Client.AccessKey = "my-access-key"
+  
 	// Create a new Exchange instance and set USD as the base currency for the exchange rates and conversion
 	ex := exchange.New("USD")
 	// convert 10 USD to EUR

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -1,13 +1,30 @@
-package exchange
+package exchange_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
+
+	"github.com/asvvvad/exchange"
 )
 
 func TestExchange(t *testing.T) {
+	ex := exchange.New("USD")
+	f, err := ex.ConvertTo("EUR", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f == nil {
+		t.Fatal("nil value")
+	}
+}
+
+func ExampleExchange() {
+	// Set exchangerate.host ACCESS_KEY - either this way or via the EXCHANGERATE_ACCESS_KEY environment variable
+	exchange.Client.AccessKey = os.Getenv("EXCHANGERATE_ACCESS_KEY")
+
 	// Create a new Exchange instance and set USD as the base currency for the exchange rates and conversion
-	ex := New("USD")
+	ex := exchange.New("USD")
 	// convert 10 USD to EUR
 	fmt.Println(ex.ConvertTo("EUR", 10))
 


### PR DESCRIPTION
It was implicit, but New overwritten the already initialized cache.

Other changes:
  * Simplify cacheDuration calculation with Time.Truncate
  * Use one parseDate for all date parsing, add error reporting.
  * Simplify and remove inefficiencies in processQuery.